### PR TITLE
docs: use proper term for training regimen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # piano-finger-placement
-Learn proper fingering techniques from pros, with coaching and mechanical testing. Works with AI to better understand the feeling and localization of the hands and prioritize a more Hanon-oriented training regime while practicing your favorite pieces.
+Learn proper fingering techniques from pros, with coaching and mechanical testing. Works with AI to better understand the feeling and localization of the hands and prioritize a more Hanon-oriented training regimen while practicing your favorite pieces.
 
 This software is entirely for educational purposes.


### PR DESCRIPTION
## Summary
- fix terminology in the README, using "training regimen" instead of "training regime"

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'piano_fingering')*

------
https://chatgpt.com/codex/tasks/task_e_689a1039a52083318af6627b433a90b8