### PR TITLE
Fix second-order DP backtracking

### DIFF
--- a/src/decoding/second_order_dp.py
+++ b/src/decoding/second_order_dp.py
@@ -68,15 +68,14 @@ def decode_monophonic_second_order(
     # Backtrack best tail (f_{N-2}, f_{N-1})
     tail = np.unravel_index(np.argmin(dp[N-1, :, :]), dp[N-1, :, :].shape)  # (f_{N-2}, f_{N-1})
     f_prev, f_cur = int(tail[0]), int(tail[1])
-    fingers = [f_prev, f_cur]
-    for i in range(N-1, 1, -1):
+    fingers = [f_cur]
+    for i in range(N-1, 0, -1):
         back_entry = back[i][f_prev][f_cur]
         if back_entry is None:
             break  # Stop backtracking if no valid entry
-        f2, f1 = back_entry
-        fingers.append(f2)
-        f_prev, f_cur = f2, f1
-    fingers = list(reversed(fingers))[1:]  # drop the leading 0 seed
+        f_prev, f_cur = back_entry
+        fingers.append(f_cur)
+    fingers.reverse()
 
     assign: Dict[int, List[int]] = {}
     for e, f in zip(seq, fingers):


### PR DESCRIPTION
## Summary
- Correct backtracking logic in second-order DP decoder by walking backwards from the best tail and constructing the finger sequence in reverse order.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'piano_fingering')*


------
https://chatgpt.com/codex/tasks/task_e_689a103c84648331b05d37ae6839bbf7