### PR TITLE
Clarify chord skipping docstring

### DIFF
--- a/src/io/musicxml.py
+++ b/src/io/musicxml.py
@@ -10,8 +10,10 @@ def load_score(path: str):
 
 def extract_monophonic_events(score) -> List[Event]:
     """
-    Flatten notes and transform into Event objects.
-    Rests and chords are skipped (decoder is currently monophonic-only).
+    Flatten notes and transform into :class:`Event` objects.
+
+    Chords are skipped explicitly while rests are inherently excluded by
+    ``score.recurse().notes``.
     """
     evts: List[Event] = []
     idx = 0


### PR DESCRIPTION
## Summary
- clarify extract_monophonic_events docstring that chords are explicitly skipped while rests are inherently excluded by score.recurse().notes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'piano_fingering')*

------
https://chatgpt.com/codex/tasks/task_e_689a104007748331acc73e66e83a1b39