### PR TITLE
Add decoding test and expose package namespace

### DIFF
--- a/piano_fingering/__init__.py
+++ b/piano_fingering/__init__.py
@@ -1,0 +1,6 @@
+"""Minimal package exposing modules under the ``piano_fingering`` namespace."""
+from pathlib import Path
+
+# Include the ``src`` directory in the package search path so submodules can be
+# imported as ``piano_fingering.<module>`` without installing the project.
+__path__.append(str(Path(__file__).resolve().parent.parent / "src"))

--- a/piano_fingering/config.py
+++ b/piano_fingering/config.py
@@ -1,0 +1,1 @@
+from .pfai.config import *

--- a/piano_fingering/constants.py
+++ b/piano_fingering/constants.py
@@ -1,0 +1,1 @@
+from .pfai.constants import *

--- a/piano_fingering/types.py
+++ b/piano_fingering/types.py
@@ -1,0 +1,1 @@
+from .pfai.types import *

--- a/src/decoding/second_order_dp.py
+++ b/src/decoding/second_order_dp.py
@@ -68,15 +68,16 @@ def decode_monophonic_second_order(
     # Backtrack best tail (f_{N-2}, f_{N-1})
     tail = np.unravel_index(np.argmin(dp[N-1, :, :]), dp[N-1, :, :].shape)  # (f_{N-2}, f_{N-1})
     f_prev, f_cur = int(tail[0]), int(tail[1])
-    fingers = [f_prev, f_cur]
+
+    # Backtrack fingers from the tail, collecting them in reverse order.
+    fingers = [f_cur, f_prev]
     for i in range(N-1, 1, -1):
         back_entry = back[i][f_prev][f_cur]
         if back_entry is None:
-            break  # Stop backtracking if no valid entry
-        f2, f1 = back_entry
-        fingers.append(f2)
-        f_prev, f_cur = f2, f1
-    fingers = list(reversed(fingers))[1:]  # drop the leading 0 seed
+            break
+        f_prev, f_cur = back_entry
+        fingers.append(f_prev)
+    fingers = list(reversed(fingers))
 
     assign: Dict[int, List[int]] = {}
     for e, f in zip(seq, fingers):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+for path in (ROOT, SRC):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -1,0 +1,16 @@
+from piano_fingering.pfai.types import Event
+from piano_fingering.decoding.second_order_dp import decode_monophonic_second_order
+from piano_fingering.pfai.config import PROFILE_M, DEFAULT_CONFIG
+
+
+def test_decode_monophonic_second_order_returns_fingers_for_events():
+    events = [
+        Event(idx=0, pitch=60, time=0.0, tied=False, slur=False, staccato=False, staff=1, is_chord=False),
+        Event(idx=1, pitch=62, time=1.0, tied=False, slur=False, staccato=False, staff=1, is_chord=False),
+    ]
+
+    mapping = decode_monophonic_second_order(events, PROFILE_M, DEFAULT_CONFIG, hand_staff=1)
+
+    assert set(mapping.keys()) == {0, 1}
+    for fingers in mapping.values():
+        assert all(f in {1, 2, 3, 4, 5} for f in fingers)


### PR DESCRIPTION
## Summary
- expose `src` modules under a lightweight `piano_fingering` namespace so tests can import package
- fix second-order decoder backtracking to return a finger for every event
- add unit test for `decode_monophonic_second_order`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a10450eec833189823a3e5ed31501