### PR TITLE
feat: add leap annotation for large intervals

### DIFF
--- a/src/annotate/notes.py
+++ b/src/annotate/notes.py
@@ -1,6 +1,11 @@
 from typing import Dict, List, Tuple
 from ..pfai.types import Event
-from ..features.patterns import is_neighbor_turn, is_repeat_reartic, is_consecutive_walkthrough
+from ..features.patterns import (
+    is_neighbor_turn,
+    is_repeat_reartic,
+    is_consecutive_walkthrough,
+    is_large_leap,
+)
 from ..pfai.config import ModelConfig as mc
 
 def collect_margin_notes(
@@ -27,4 +32,11 @@ def collect_margin_notes(
                 notes.append((e0.time, f"Rollover 1–3–1 ({hand_label})"))
             elif is_consecutive_walkthrough(f2, f1, f0):
                 notes.append((e0.time, f"Avoided walk‑through ({hand_label})"))
+
+    for i in range(1, len(seq)):
+        e_prev, e_cur = seq[i-1], seq[i]
+        f_cur = fingering[e_cur.idx][0]
+        if is_large_leap(e_prev.pitch, e_cur.pitch, cfg):
+            notes.append((e_prev.time, f"Move early ({hand_label})"))
+            notes.append((e_cur.time, f"Aim {f_cur} ({hand_label})"))
     return notes

--- a/src/features/patterns.py
+++ b/src/features/patterns.py
@@ -18,3 +18,10 @@ def is_consecutive_walkthrough(f2: int, f1: int, f0: int) -> bool:
     Penalized across A–B–A to preserve hand frame.
     """
     return (abs(f2 - f1) == 1) and (abs(f1 - f0) == 1) and ((f2 < f1 < f0) or (f2 > f1 > f0))
+
+def is_large_leap(m_prev: int, m_cur: int, cfg: ModelConfig) -> bool:
+    """
+    True when the interval between two notes exceeds the configured leap size.
+    Used to trigger preparatory technique annotations for big jumps.
+    """
+    return abs(m_cur - m_prev) > cfg.large_leap_semitones

--- a/src/pfai/config.py
+++ b/src/pfai/config.py
@@ -42,6 +42,8 @@ class ModelConfig:
     # Rollover window detection tolerance (in semitones)
     neighbor_turn_max_interval: int = 2  # allows up to whole-step around center
     repeat_near_max_interval: int = 2    # A–A–near
+    # Large leap detection threshold (in semitones)
+    large_leap_semitones: int = 12       # leaps larger than an octave trigger guidance
 
 # Predefined hand sizes
 PROFILE_S  = HandProfile('S',  9, 10)

--- a/tests/test_leap_annotations.py
+++ b/tests/test_leap_annotations.py
@@ -1,0 +1,22 @@
+from piano_fingering.annotate.notes import collect_margin_notes
+from piano_fingering.pfai.config import DEFAULT_CONFIG
+from piano_fingering.features.patterns import is_large_leap
+from piano_fingering.pfai.types import Event
+
+
+def test_is_large_leap_detection():
+    cfg = DEFAULT_CONFIG
+    assert not is_large_leap(60, 71, cfg)  # less than octave
+    assert is_large_leap(60, 75, cfg)  # greater than octave
+
+
+def test_collect_margin_notes_for_leap():
+    cfg = DEFAULT_CONFIG
+    events = [
+        Event(idx=0, pitch=60, time=0.0, tied=False, slur=False, staccato=False, staff=1, is_chord=False),
+        Event(idx=1, pitch=76, time=1.0, tied=False, slur=False, staccato=False, staff=1, is_chord=False),
+    ]
+    fingering = {0: [1], 1: [3]}
+    notes = collect_margin_notes(events, fingering, cfg, "RH")
+    assert (0.0, "Move early (RH)") in notes
+    assert (1.0, "Aim 3 (RH)") in notes


### PR DESCRIPTION
## Summary
- detect large leaps using configurable semitone threshold
- emit "Move early" and "Aim finger" notes for big jumps
- add tests for leap detection and annotations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a12fce67c8331a790264ea740f398