### PR TITLE
Allow exporting annotated scores to PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # piano-finger-placement
 Learn proper fingering techniques from pros, with coaching and mechanical testing. Works with AI to better understand the feeling and localization of the hands and prioritize a more Hanon-oriented training regimen while practicing your favorite pieces.
 
+The CLI tool writes annotated scores back to MusicXML and can optionally render
+them directly to PDF for convenient printing or sharing.
+
 This software is entirely for educational purposes.

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -25,7 +25,11 @@ def app():
 
     parser = argparse.ArgumentParser(description="Piano Fingering auto-annotator (monophonic, rollover-aware).")
     parser.add_argument("--infile", required=True, help="Input MusicXML file")
-    parser.add_argument("--outfile", required=True, help="Output MusicXML file")
+    parser.add_argument(
+        "--outfile",
+        required=True,
+        help="Output MusicXML or PDF file",
+    )
     parser.add_argument("--hand-profile", default="M", choices=["S","M","L","XL"], help="Hand size profile")
     parser.add_argument("--staff", default="both", choices=["RH","LH","both"], help="Which staff to process")
     # Optional overrides for key weights (so you can tune without editing code)

--- a/src/io/musicxml.py
+++ b/src/io/musicxml.py
@@ -1,5 +1,8 @@
 from typing import List
+from pathlib import Path
+
 from music21 import converter, note, chord, expressions, articulations, stream
+
 from ..pfai.types import Event
 
 def load_score(path: str):
@@ -45,7 +48,10 @@ def write_fingerings_and_notes(src_path: str,
                                fingering_map: dict[int, list[int]],
                                margin_notes: list[tuple[float, str]]) -> None:
     """
-    Writes finger numbers and margin notes back to a MusicXML file.
+    Write finger numbers and margin notes to a score and export it.
+
+    ``out_path`` may point to either a MusicXML file (default) or a PDF. The
+    latter will be rendered via :mod:`music21`'s PDF backend.
     """
     s = converter.parse(src_path)
 
@@ -69,5 +75,10 @@ def write_fingerings_and_notes(src_path: str,
             # layout can fail on some imported editions; ignore rather than crash
             pass
 
-    s.write('musicxml', out_path)
+    # Choose output based on extension; default to MusicXML
+    out = Path(out_path)
+    if out.suffix.lower() == ".pdf":
+        s.write("musicxml.pdf", str(out))
+    else:
+        s.write("musicxml", str(out))
     


### PR DESCRIPTION
## Summary
- add PDF output support to `write_fingerings_and_notes`
- update CLI help to accept MusicXML or PDF output paths
- document PDF export capability in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a1bf4d9a083319643c72110be0dfa